### PR TITLE
Explain why worker_processes must be set to 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ Requirements:
 Server-side configuration:
   - Set nginx.conf as the live nginx conf (location of file depends on system)
   - Set the web root to an appropriate value
-  - Adjust worker_processes and worker_connections to sane values for the platform
+  - Adjust worker_connections to a sane value for the platform
+  - Set worker_processes to 1 to work around an issue in the nginx-rtmp module.
   - Set the name of the rtmp server application block to whatever is desired (defaults to "stream")
   - Place the .php/.html files in the web root and adjust the on_publish directive url to reflect the location of auth.php
   - Set MySQL-related variables in common.php ($host, $username, $password, $dbname, $usertablename)

--- a/php/nginx.conf
+++ b/php/nginx.conf
@@ -1,5 +1,9 @@
 user www;
 
+# worker_processes must be 1 for RTMP purposes.
+# This is due to an issue in the implementation that will not allow
+# viewers to access a stream in progress if there is more than one
+# worker process.
 worker_processes  1;
 
 events {
@@ -25,7 +29,7 @@ rtmp {
         server {
                 listen 1935;
                 chunk_size 4096;
-
+		
                 application stream {
                         live on;
                         record off;

--- a/python/nginx.conf
+++ b/python/nginx.conf
@@ -1,5 +1,9 @@
 user www;
 
+# worker_processes must be 1 for RTMP purposes.
+# This is due to an issue in the implementation that will not allow
+# viewers to access a stream in progress if there is more than one
+# worker process.
 worker_processes  1;
 
 events {


### PR DESCRIPTION
The existing configuration explanation completely ignores the fact that `worker_processes` _must_ be set to `1` for things to work as one would expect them to.
